### PR TITLE
do not copy wrappers to llvm

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,1 @@
-file(COPY clang-archer clang-archer++
-  DESTINATION ${LLVM_TOOLS_BINARY_DIR})
 install(PROGRAMS clang-archer clang-archer++ DESTINATION bin)


### PR DESCRIPTION
I don't think we can/should always assume that the llvm installation directory is writeable. It is probably also not wise to put the clang-archer wrappers in there at configure time anyway.