### PR TITLE
generate wrappers with full paths

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,3 @@
-install(PROGRAMS clang-archer clang-archer++ DESTINATION bin)
+configure_file(clang-archer.in clang-archer)
+configure_file(clang-archer++.in clang-archer++)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/clang-archer ${CMAKE_CURRENT_BINARY_DIR}/clang-archer++ DESTINATION bin)

--- a/tools/clang-archer++.in
+++ b/tools/clang-archer++.in
@@ -45,4 +45,4 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-clang++ -Xclang -load -Xclang LLVMArcher.so -fopenmp -fsanitize=thread -g $@
+@LLVM_ROOT@/bin/clang++ -Xclang -load -Xclang @CMAKE_INSTALL_PREFIX@/lib/LLVMArcher.so -fopenmp -fsanitize=thread -g -L@OMP_PREFIX@/lib -Wl,-rpath=@OMP_PREFIX@/lib $@

--- a/tools/clang-archer.in
+++ b/tools/clang-archer.in
@@ -45,4 +45,4 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-clang -Xclang -load -Xclang LLVMArcher.so -fopenmp -fsanitize=thread -g $@
+@LLVM_ROOT@/bin/clang -Xclang -load -Xclang @CMAKE_INSTALL_PREFIX@/lib/LLVMArcher.so -fopenmp -fsanitize=thread -g -L@OMP_PREFIX@/lib -Wl,-rpath=@OMP_PREFIX@/lib $@


### PR DESCRIPTION
The clang-archer and clang-archer++ scripts required setting LD_LIBRARY_PATH and ensuring that clang/clang++ were in ones $PATH. It also had an issue that if the clang installation had its own OpenMP library, while Archer was built with a side-install OpenMP runtime (i.e., with OMPT support), the OpenMP runtime from clang would be chosen instead of the side-installed one. This PR fixes these issues by hardcoding the path to the compiler and to the archer plugin. It also sets an rpath to the OpenMP runtime that Archer was configured against.