### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   # - git clone https://github.com/OpenMPToolsInterface/LLVM-openmp.git openmp
   - git clone https://github.com/llvm-mirror/openmp.git
   - export OPENMP_INSTALL=$HOME/usr
-  - cd openmp/runtime
+  - cd openmp
   - mkdir build && cd build
   - cmake -G Ninja -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX:PATH=$OPENMP_INSTALL -D LIBOMP_OMPT_SUPPORT=on -D LIBOMP_OMPT_OPTIONAL=on ..
   - ninja -j4 -l4


### PR DESCRIPTION
Fix building stand-alone version of OpenMP runtime. Latest OpenMP runtime must be built from repository root directory.