### PR TITLE
Use arg_iterator instead of getArgumentList()

### DIFF
--- a/lib/Transforms/Instrumentation/InstrumentParallel.cpp
+++ b/lib/Transforms/Instrumentation/InstrumentParallel.cpp
@@ -266,8 +266,8 @@ bool InstrumentParallel::runOnFunction(Function &F) {
     ValueToValueMapTy VMap;
     Function *new_function = CloneFunction(&F, VMap);
     new_function->setName(functionName + "__swordomp__");
-    Function::ArgumentListType::iterator it = F.getArgumentList().begin();
-    Function::ArgumentListType::iterator end = F.getArgumentList().end();
+    Function::arg_iterator it = F.arg_begin();
+    Function::arg_iterator end = F.arg_end();
     std::vector<Value*> args;
     while (it != end) {
       Argument *Args = &(*it);


### PR DESCRIPTION
This is backward compatible and favors new LLVM/Clang releases

Also see the benefits here: https://reviews.llvm.org/D31052