### PR TITLE
Fixed runningOnValgrind on OSX

### DIFF
--- a/rtl/ompt-tsan.cpp
+++ b/rtl/ompt-tsan.cpp
@@ -142,36 +142,42 @@ extern "C" {
     fptr = (void (*)(const char *, int, const volatile void *))dlsym(RTLD_DEFAULT, "AnnotateHappensAfter");
     (*fptr)(file,line,cv);
   }
+
   static void AnnotateHappensBefore(const char *file, int line, const volatile void *cv){
     void (*fptr)(const char *, int, const volatile void *);
 
     fptr = (void (*)(const char *, int, const volatile void *))dlsym(RTLD_DEFAULT, "AnnotateHappensBefore");
     (*fptr)(file,line,cv);
   }
+
   static void AnnotateIgnoreWritesBegin(const char *file, int line){
     void (*fptr)(const char *, int);
 
     fptr = (void (*)(const char *, int))dlsym(RTLD_DEFAULT, "AnnotateIgnoreWritesBegin");
     (*fptr)(file,line);
   }
+
   static void AnnotateIgnoreWritesEnd(const char *file, int line){
     void (*fptr)(const char *, int);
 
     fptr = (void (*)(const char *, int))dlsym(RTLD_DEFAULT, "AnnotateIgnoreWritesEnd");
     (*fptr)(file,line);
   }
+
   static void AnnotateNewMemory(const char *file, int line, const volatile void *cv, size_t size){
     void (*fptr)(const char *, int, const volatile void *,size_t);
 
     fptr = (void (*)(const char *, int, const volatile void *,size_t))dlsym(RTLD_DEFAULT, "AnnotateNewMemory");
     (*fptr)(file,line,cv,size);
   }
+
   static int RunningOnValgrind(){
     int (*fptr)();
 
     fptr = (int (*)())dlsym(RTLD_DEFAULT, "RunningOnValgrind");
-    if (fptr==NULL || fptr != RunningOnValgrind)
+    if (fptr == NULL)
       runOnTsan = 0;
+
     return 0;
   }
 #else
@@ -994,8 +1000,9 @@ ompt_start_tool_result_t* ompt_start_tool(
   static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_tsan_initialize,&ompt_tsan_finalize, {0}};
   runOnTsan=1;
   RunningOnValgrind();
-  if (!runOnTsan) // if we are not running on TSAN, give a different tool the chance to be loaded
+  if (!runOnTsan) { // if we are not running on TSAN, give a different tool the chance to be loaded
     return NULL;
+  }
 
   return &ompt_start_tool_result;
 }

--- a/tools/clang-archer++.in
+++ b/tools/clang-archer++.in
@@ -73,16 +73,16 @@ done
 
 if [ $linking == yes ] ; then
     if [ @LIBOMP_TSAN_SUPPORT@ == FALSE ] ; then
-  	link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath=@OMP_PREFIX@/lib -L@CMAKE_INSTALL_PREFIX@/lib -Wl,-rpath=@CMAKE_INSTALL_PREFIX@/lib -larcher"
+        link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath,@OMP_PREFIX@/lib -L@CMAKE_INSTALL_PREFIX@/lib -Wl,-rpath,@CMAKE_INSTALL_PREFIX@/lib -larcher"
     else
-  	link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath=@OMP_PREFIX@/lib"
+        link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath,@OMP_PREFIX@/lib"
     fi
 else
   link_flags=""
 fi
 
 if [ "$static_analysis" == "true" ]; then
-    @LLVM_ROOT@/bin/clang++ -I@OMP_PREFIX@/include -Xclang -load -Xclang @CMAKE_INSTALL_PREFIX@/lib/LLVMArcher.so -fopenmp -fsanitize=thread $link_flags -g "$@"
+    @LLVM_ROOT@/bin/clang++ -I@OMP_PREFIX@/include -Xclang -load -Xclang @CMAKE_INSTALL_PREFIX@/lib/LLVMArcher@CMAKE_SHARED_LIBRARY_SUFFIX@ -fopenmp -fsanitize=thread $link_flags -g "$@"
 else
     @LLVM_ROOT@/bin/clang++ -I@OMP_PREFIX@/include -fopenmp -fsanitize=thread $link_flags -g "$@"
 fi

--- a/tools/clang-archer.in
+++ b/tools/clang-archer.in
@@ -73,16 +73,16 @@ done
 
 if [ $linking == yes ] ; then
     if [ @LIBOMP_TSAN_SUPPORT@ == FALSE ] ; then
-  	link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath=@OMP_PREFIX@/lib -L@CMAKE_INSTALL_PREFIX@/lib -Wl,-rpath=@CMAKE_INSTALL_PREFIX@/lib -larcher"
+        link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath,@OMP_PREFIX@/lib -L@CMAKE_INSTALL_PREFIX@/lib -Wl,-rpath,@CMAKE_INSTALL_PREFIX@/lib -larcher"
     else
-  	link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath=@OMP_PREFIX@/lib"
+        link_flags="-L@OMP_PREFIX@/lib -Wl,-rpath,@OMP_PREFIX@/lib"
     fi
 else
   link_flags=""
 fi
 
 if [ "$static_analysis" == "true" ]; then
-    @LLVM_ROOT@/bin/clang -I@OMP_PREFIX@/include -Xclang -load -Xclang @CMAKE_INSTALL_PREFIX@/lib/LLVMArcher.so -fopenmp -fsanitize=thread $link_flags -g "$@"
+    @LLVM_ROOT@/bin/clang -I@OMP_PREFIX@/include -Xclang -load -Xclang @CMAKE_INSTALL_PREFIX@/lib/LLVMArcher@CMAKE_SHARED_LIBRARY_SUFFIX@ -fopenmp -fsanitize=thread $link_flags -g "$@"
 else
     @LLVM_ROOT@/bin/clang -I@OMP_PREFIX@/include -fopenmp -fsanitize=thread $link_flags -g "$@"
 fi


### PR DESCRIPTION
@jprotze I fixed the driver for OSX since it was using the wrong library extension. Also I fix the runninOnValgrind function, however now it does not report any false alarm but it does not catch any racy. I verified that the "AnnotateHappens..." get called correctly but I can't figure out why on OSX it does not find any race.