### PR TITLE
build system fixes for llvm 7 and above

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,10 +66,24 @@ set(LIBARCHER_SOURCE_FILES
   Transforms/Instrumentation/InstrumentParallel.cpp
   )
 
-add_llvm_loadable_module(LLVMArcher
-  ${LIBARCHER_SOURCE_FILES}
-  ${LIBARCHER_HEADER_FILES}
-  )
+if (CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
+  add_llvm_loadable_module(LLVMArcher
+    ${LIBARCHER_SOURCE_FILES}
+    ${LIBARCHER_HEADER_FILES}
+    )
+else()
+  if (CMAKE_C_COMPILER_VERSION VERSION_LESS 8.0)
+    llvm_add_library(LLVMArcher MODULE
+      ${LIBARCHER_SOURCE_FILES}
+      ${LIBARCHER_HEADER_FILES}
+      )
+  else()
+    add_llvm_library(LLVMArcher MODULE
+      ${LIBARCHER_SOURCE_FILES}
+      ${LIBARCHER_HEADER_FILES}
+      )
+  endif()
+endif()
 
 # This declares the dependency to the generated Attributes.gen file,
 # which is included by serveral indirections (target is provided by


### PR DESCRIPTION
it appears this macro in LLVM has changed in version 7 and again in version 8. This PR will adapt is use of the macro accordingly.